### PR TITLE
fix a bug for macOS builds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1641,7 +1641,7 @@ mod sys {
             Ok(events.len)
         }
     }
-    const FFLAGS: EventFlag = EventFlag::empty();
+    const FFLAGS: FilterFlag = FilterFlag::empty();
 
     pub struct Events {
         list: Box<[KEvent]>,


### PR DESCRIPTION
Hello,

It look like we have a small typo here and create an EventFlag instead of a FilterFlag.
It was causing multiple issue with the call to [`KEvent::new`](https://docs.rs/nix/0.17.0/x86_64-apple-darwin/nix/sys/event/struct.KEvent.html#method.new).