### PR TITLE
Rename tokio feature to tokio02

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,17 @@ edition = "2018"
 description = "WIP"
 license = "MIT OR Apache-2.0"
 
+[features]
+# Optional feature for seamless integration with crates depending on tokio.
+# It creates a global tokio runtime and sets up its context inside smol.
+#
+# Enable the feature as follows:
+# ```
+# [dependencies]
+# smol = { version = "1", features = ["tokio02"] }
+# ```
+tokio02 = ["tokio"]
+
 [dependencies]
 async-task = "3.0.0"
 crossbeam = "0.7.3"
@@ -16,14 +27,6 @@ scoped-tls-hkt = "0.1.2"
 slab = "0.4.2"
 socket2 = { version = "0.3.12", features = ["pair", "unix"] }
 
-# Optional feature for seamless integration with crates depending on tokio.
-# It creates a global tokio runtime and sets up its context inside smol.
-#
-# Enable the feature as follows:
-# ```
-# [dependencies]
-# smol = { version = "1", features = ["tokio"] }
-# ```
 [dependencies.tokio]
 version = "0.2.18"
 default-features = false
@@ -59,7 +62,7 @@ num_cpus = "1.13.0"
 reqwest = "0.10.4"
 scraper = "0.11.0"
 signal-hook = "0.1.13"
-smol = { path = ".", features = ["tokio"] }
+smol = { path = ".", features = ["tokio02"] }
 surf = { version = "2.0.0-alpha.1", default-features = false, features = ["h1-client"] }
 tempfile = "3.1.0"
 tokio = { version = "0.2.18", default-features = false }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Enable the feature as follows:
 
 ```toml
 [dependencies]
-smol = { version = "1", features = ["tokio"] }
+smol = { version = "1", features = ["tokio02"] }
 ```
 
 [async-std]: https://docs.rs/async-std

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,10 +4,10 @@
 
 /// Enters the tokio context if the `tokio` feature is enabled.
 pub(crate) fn enter<T>(f: impl FnOnce() -> T) -> T {
-    #[cfg(not(feature = "tokio"))]
+    #[cfg(not(feature = "tokio02"))]
     return f();
 
-    #[cfg(feature = "tokio")]
+    #[cfg(feature = "tokio02")]
     {
         use once_cell::sync::Lazy;
         use tokio::runtime::Runtime;


### PR DESCRIPTION
I don't know if a dedicated feature is needed when the next version of Tokio is released, but given that discussions about Tokio 0.3 have already begun, I feel it maybe makes sense to include the version number in the feature name.
