### PR TITLE
Bump dev-dependencies for examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ anyhow = "1.0.37"
 async-dup = "1.2.2"
 async-h1 = "2.3.0"
 async-native-tls = "0.3.3"
-async-std = "1.8.0"
-async-tungstenite = { version = "0.11.0", features = ["async-native-tls"] }
+async-std = "1.9.0"
+async-tungstenite = { version = "0.12.0", features = ["async-native-tls"] }
 base64 = "0.13.0"
 ctrlc = "3.1.6"
 doc-comment = "0.3.3"
@@ -42,11 +42,11 @@ native-tls = "0.2.7"
 num_cpus = "1.13.0"
 scraper = "0.12.0"
 signal-hook = "0.3.2"
-surf = { version = "2.0.0-alpha.5", default-features = false, features = ["h1-client"] }
-tempfile = "3.1.0"
+surf = { version = "2.1.0", default-features = false, features = ["h1-client"] }
+tempfile = "3.2.0"
 tide = "0.15.0"
 tokio = { version = "1.0.1", default-features = false, features = ["rt-multi-thread"] }
-tungstenite = "0.11.1"
+tungstenite = "0.12.0"
 url = "2.2.0"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,34 +25,34 @@ futures-lite = "1.11.0"
 once_cell = "1.4.1"
 
 [dev-dependencies]
-anyhow = "1.0.32"
+anyhow = "1.0.37"
 async-dup = "1.2.2"
-async-h1 = "2.1.2"
+async-h1 = "2.3.0"
 async-native-tls = "0.3.3"
-async-std = "1.6.4"
-async-tungstenite = { version = "0.8.0", features = ["async-native-tls"] }
-base64 = "0.12.3"
+async-std = "1.8.0"
+async-tungstenite = { version = "0.11.0", features = ["async-native-tls"] }
+base64 = "0.13.0"
 ctrlc = "3.1.6"
 doc-comment = "0.3.3"
-futures = "0.3.5"
-http = "0.2.1"
-http-types = "2.4.0"
-hyper = { version = "0.13.8", default-features = false, features = ["stream"] }
-native-tls = "0.2.4"
+futures = "0.3.8"
+http = "0.2.2"
+http-types = "2.9.0"
+hyper = { version = "0.14.2", default-features = false, features = ["client", "http1", "server", "stream"] }
+native-tls = "0.2.7"
 num_cpus = "1.13.0"
 scraper = "0.12.0"
-signal-hook = "0.1.16"
+signal-hook = "0.3.2"
 surf = { version = "2.0.0-alpha.5", default-features = false, features = ["h1-client"] }
 tempfile = "3.1.0"
-tide = "0.13.0"
-tokio = { version = "0.2.22", default-features = false, features = ["rt-threaded"] }
+tide = "0.15.0"
+tokio = { version = "1.0.1", default-features = false, features = ["rt-multi-thread"] }
 tungstenite = "0.11.1"
-url = "2.1.1"
+url = "2.2.0"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
-inotify = { version = "0.8.3", default-features = false }
-nix = "0.18.0"
-timerfd = "1.1.1"
+inotify = { version = "0.9.2", default-features = false }
+nix = "0.19.1"
+timerfd = "1.2.0"
 
 [target.'cfg(windows)'.dev-dependencies]
 uds_windows = "0.1.5"


### PR DESCRIPTION
Updates the dependencies used by examples to current - some have had API-breaking changes, so some examples are updated to catch up with those as well.

Note that the hyper-server example doesn't seem to work when tested, but it also didn't work before this PR. Looked at it a bit and found that poll_accept() returns Pending via incoming.poll_next() and then poll_accept() isn't invoked again. hyper-client meanwhile works fine, so the issue doesn't seem to be related to the AsyncRead updates.