### PR TITLE
Temporarily disable example that using surf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,8 @@ native-tls = "0.2.7"
 num_cpus = "1.13.0"
 scraper = "0.12.0"
 signal-hook = "0.3.2"
-surf = { version = "2.1.0", default-features = false, features = ["h1-client"] }
+# TODO: surf is currently broken: https://github.com/http-rs/surf/pull/282
+# surf = { version = "2.1.0", default-features = false, features = ["h1-client"] }
 tempfile = "3.2.0"
 tide = "0.15.0"
 tokio = { version = "1.0.1", default-features = false, features = ["rt-multi-thread"] }

--- a/examples/web-crawler.rs
+++ b/examples/web-crawler.rs
@@ -1,3 +1,6 @@
+fn main() {}
+
+/* TODO: surf is currently broken: https://github.com/http-rs/surf/pull/282
 //! Crawls the Rust language website and prints found pages.
 //!
 //! Run with:
@@ -78,3 +81,4 @@ fn main() -> Result<()> {
         Ok(())
     })
 }
+*/


### PR DESCRIPTION
surf is currently broken: https://github.com/http-rs/surf/pull/282, https://github.com/smol-rs/smol/runs/1896315168?check_suite_focus=true
I submitted a fix, but I'm not sure if it will be merged & released soon.