### PR TITLE
Remove readme field from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ homepage = "https://github.com/smol-rs/smol"
 documentation = "https://docs.rs/smol"
 keywords = ["async", "await", "future", "io", "networking"]
 categories = ["asynchronous", "concurrency", "network-programming"]
-readme = "README.md"
 
 [dependencies]
 async-channel = "1.4.2"


### PR DESCRIPTION
Since 1.46, cargo can automatically detect the value of the readme field.