### PR TITLE
Replace once-cell with async-lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,11 @@ async-channel = "1.4.2"
 async-executor = "1.3.0"
 async-fs = "1.3.0"
 async-io = "1.1.2"
-async-lock = "2.3.0"
+async-lock = "2.6.0"
 async-net = "1.4.3"
 async-process = "1.0.0"
 blocking = "1.0.0"
 futures-lite = "1.11.0"
-once_cell = "1.4.1"
 
 [dev-dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,13 @@ exclude = ["/.*"]
 
 [dependencies]
 async-channel = "1.4.2"
-async-executor = "1.3.0"
+async-executor = "1.5.0"
 async-fs = "1.3.0"
-async-io = "1.1.2"
+async-io = "1.12.0"
 async-lock = "2.6.0"
 async-net = "1.4.3"
-async-process = "1.0.0"
-blocking = "1.0.0"
+async-process = "1.6.0"
+blocking = "1.3.0"
 futures-lite = "1.11.0"
 
 [dev-dependencies]


### PR DESCRIPTION
`smol` relies on `once_cell`, which has caused it to violate its MSRV of 1.47. This crate replaces `once_cell` with `async_lock`, in a similar manner to smol-rs/async-io#93