### PR TITLE
Add an official MSRV policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         # When updating this, the reminder to update the minimum supported
-        # Rust version in Cargo.toml.
+        # Rust version in Cargo.toml and README.md.
         rust: ['1.47']
     steps:
       - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Another useful tool for making certificates is [mkcert].
 
 ## MSRV Policy
 
-The Minimum Supported Rust Version (MSRV) of this crate is **1.47**. As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Stable](https://packages.debian.org/stable/rust/rustc). At the time of writing, this version of Rust is *1.48.0*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
+The Minimum Supported Rust Version (MSRV) of this crate is **1.47**. As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Stable](https://packages.debian.org/stable/rust/rustc). At the time of writing, this version of Rust is *1.48*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Another useful tool for making certificates is [mkcert].
 
 [mkcert]: https://github.com/FiloSottile/mkcert
 
+## MSRV Policy
+
+The Minimum Supported Rust Version (MSRV) of this crate is **1.47.0**. As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Stable](https://packages.debian.org/stable/rust/rustc). At the time of writing, this version of Rust is *1.48.0*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
+
 ## License
 
 Licensed under either of

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Another useful tool for making certificates is [mkcert].
 
 ## MSRV Policy
 
-The Minimum Supported Rust Version (MSRV) of this crate is **1.47.0**. As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Stable](https://packages.debian.org/stable/rust/rustc). At the time of writing, this version of Rust is *1.48.0*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
+The Minimum Supported Rust Version (MSRV) of this crate is **1.47**. As a **tentative** policy, the MSRV will not advance past the [current Rust version provided by Debian Stable](https://packages.debian.org/stable/rust/rustc). At the time of writing, this version of Rust is *1.48.0*. However, the MSRV may be advanced further in the event of a major ecosystem shift or a security vulnerability.
 
 ## License
 


### PR DESCRIPTION
So far, the unofficial MSRV policy of the `smol-rs` organization is to keep the MSRV at or below the current Debian stable version. However, as far as I know this is never written down anywhere. Therefore, this PR attempts to codify this policy.

I can add this to the other crates in the `smol-rs` organization if this is approved.