### PR TITLE
Fix deprecated warning in example

### DIFF
--- a/examples/linux-inotify.rs
+++ b/examples/linux-inotify.rs
@@ -35,7 +35,10 @@ fn main() -> std::io::Result<()> {
     smol::block_on(async {
         // Watch events in the current directory.
         let mut inotify = Async::new(Inotify::init()?)?;
-        inotify.get_mut().add_watch(".", WatchMask::ALL_EVENTS)?;
+        inotify
+            .get_mut()
+            .watches()
+            .add(".", WatchMask::ALL_EVENTS)?;
         println!("Watching for filesystem events in the current directory...");
         println!("Try opening a file to trigger some events.");
         println!();


### PR DESCRIPTION
```
error: use of deprecated method `inotify::Inotify::add_watch`: use `Inotify.watches().add()` instead
  --> examples/linux-inotify.rs:38:27
   |
38 |         inotify.get_mut().add_watch(".", WatchMask::ALL_EVENTS)?;
   |                           ^^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
```