### PR TITLE
Support for the ESP-IDF framework

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,11 @@ async-fs = "1.3.0"
 async-io = "1.12.0"
 async-lock = "2.6.0"
 async-net = "1.4.3"
-async-process = "1.6.0"
 blocking = "1.3.0"
 futures-lite = "1.11.0"
+
+[target.'cfg(not(target_os = "espidf"))'.dependencies]
+async-process = "1.6.0"
 
 [dev-dependencies]
 anyhow = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,11 @@ pub use {
 };
 
 #[doc(inline)]
-pub use {
-    async_channel as channel, async_fs as fs, async_lock as lock, async_net as net,
-    async_process as process,
-};
+pub use {async_channel as channel, async_fs as fs, async_lock as lock, async_net as net};
+
+#[cfg(not(target_os = "espidf"))]
+#[doc(inline)]
+pub use async_process as process;
 
 mod spawn;
 pub use spawn::spawn;


### PR DESCRIPTION
`async-process` does not make sense on the ESP IDF as this framework simply does not have multiple processes and signals, so that crate will likely never be supported there.

Yet - for user convenience - perhaps it does make sense to have the `smol` aggregation crate supported there. With everything except the `async-process` re-export.