### PR TITLE
Use rustix in linux-timerfd example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ url = "2"
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
 inotify = { version = "0.10", default-features = false }
-nix = "0.27"
+rustix = "0.38"
 timerfd = "1"
 
 [target.'cfg(windows)'.dev-dependencies]

--- a/examples/linux-timerfd.rs
+++ b/examples/linux-timerfd.rs
@@ -8,7 +8,6 @@
 
 #[cfg(target_os = "linux")]
 fn main() -> std::io::Result<()> {
-    use std::os::unix::io::AsRawFd;
     use std::time::{Duration, Instant};
 
     use smol::{io, Async};
@@ -22,7 +21,7 @@ fn main() -> std::io::Result<()> {
 
         // When the OS timer fires, a 64-bit integer can be read from it.
         Async::new(timer)?
-            .read_with(|t| nix::unistd::read(t.as_raw_fd(), &mut [0u8; 8]).map_err(io::Error::from))
+            .read_with(|t| rustix::io::read(t, &mut [0u8; 8]).map_err(io::Error::from))
             .await?;
         Ok(())
     }


### PR DESCRIPTION
smol-rs crates already depend on rustix.