### PR TITLE
v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.0.0
+
+- **Breaking:** Bump subcrates to their newest major versions. (#277, #280, #281, #282, #283)
+- Run the `async-process` driver on the executor. (#284)
+
 # Version 1.3.0
 
 - Remove the dependency on the `once_cell` crate to restore the MSRV. (#241)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,8 +2,8 @@
 name = "smol"
 # When publishing a new version:
 # - Update CHANGELOG.md
-# - Create "v1.x.y" git tag
-version = "1.3.0"
+# - Create "v2.x.y" git tag
+version = "2.0.0"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.63"


### PR DESCRIPTION
- **Breaking:** Bump subcrates to their newest major versions. (#277, #280, #281, #282, #283)
- Run the `async-process` driver on the executor. (#284)
