### PR TITLE
v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Version 2.0.1
+
+- Add a mention to the documentation of `smol::spawn` that tasks spawned with
+  this function don't have their destructors called when the program ends. (#312)
+
 # Version 2.0.0
 
 - **Breaking:** Bump subcrates to their newest major versions. (#277, #280, #281, #282, #283)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "smol"
 # When publishing a new version:
 # - Update CHANGELOG.md
 # - Create "v2.x.y" git tag
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
 edition = "2018"
 rust-version = "1.63"


### PR DESCRIPTION
- Add a mention to the documentation of `smol::spawn` that tasks spawned with this function don't have their destructors called when the program ends. (#312)
