### PR TITLE
Update docs to mention smol-macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This crate simply re-exports other smaller async crates (see the source).
 To use tokio-based libraries with smol, apply the [`async-compat`] adapter to futures and I/O
 types.
 
+See the [`smol-macros`] crate if you want a no proc-macro, fast compiling, easy-to-use
+async main and/or multi-threaded Executor setup out of the box.
+
 ## Examples
 
 Connect to an HTTP website, make a GET request, and pipe the response to the standard output:
@@ -42,9 +45,9 @@ fn main() -> io::Result<()> {
 
 There's a lot more in the [examples] directory.
 
-[`async-compat`]: https://docs.rs/async-compat
+[`async-compat`]: https://docs.rs/async-compat/latest/async_compat/
+[`smol-macros`]: https://docs.rs/smol-macros/latest/smol_macros/
 [examples]: https://github.com/smol-rs/smol/tree/master/examples
-[get-request]: https://github.com/smol-rs/smol/blob/master/examples/get-request.rs
 
 ## Subcrates
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,9 @@
 //! To use tokio-based libraries with smol, apply the [`async-compat`] adapter to futures and I/O
 //! types.
 //!
+//! See the [`smol-macros`] crate if you want a no proc-macro, fast compiling, easy-to-use
+//! async main and/or multi-threaded Executor setup out of the box.
+//!
 //! # Examples
 //!
 //! Connect to an HTTP website, make a GET request, and pipe the response to the standard output:
@@ -27,9 +30,9 @@
 //!
 //! There's a lot more in the [examples] directory.
 //!
-//! [`async-compat`]: https://docs.rs/async-compat
+//! [`async-compat`]: https://docs.rs/async-compat/latest/async_compat/
+//! [`smol-macros`]: https://docs.rs/smol-macros/latest/smol_macros/
 //! [examples]: https://github.com/smol-rs/smol/tree/master/examples
-//! [get-request]: https://github.com/smol-rs/smol/blob/master/examples/get-request.rs
 
 #![doc(
     html_favicon_url = "https://raw.githubusercontent.com/smol-rs/smol/master/assets/images/logo_fullsize_transparent.png"


### PR DESCRIPTION
The smol-macros crate internals are a bit complex to explain.

For now, I think linking the smol-macros docs will at least help people on the right path to figure out something.

Partially deals with #317 but more detail about how Executor runs tasks on multiple threads (the caller needs to set up the threads and call block on with run on each thread to make the Executor run on those threads.)

More detail can be added in later PRs.