### PR TITLE
Define our own prelude module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub use {
     async_executor::{Executor, LocalExecutor, Task},
     async_io::{block_on, Async, Timer},
     blocking::{unblock, Unblock},
-    futures_lite::{future, io, pin, prelude, ready, stream},
+    futures_lite::{future, io, pin, ready, stream},
 };
 
 #[doc(inline)]
@@ -60,6 +60,8 @@ pub use {async_channel as channel, async_fs as fs, async_lock as lock, async_net
 #[cfg(not(target_os = "espidf"))]
 #[doc(inline)]
 pub use async_process as process;
+
+pub mod prelude;
 
 mod spawn;
 pub use spawn::spawn;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,0 +1,25 @@
+//! Traits [`Future`], [`Stream`], [`AsyncRead`], [`AsyncWrite`], [`AsyncBufRead`],
+//! [`AsyncSeek`], and their extensions.
+//!
+//! # Examples
+//!
+//! ```
+//! use smol::prelude::*;
+//! ```
+
+// Define our own prelude module instead of re-exporting from futures-lite,
+// because rustdoc issue: https://github.com/smol-rs/smol/issues/354
+
+#[doc(no_inline)]
+pub use crate::{
+    future::{Future, FutureExt as _},
+    stream::{Stream, StreamExt as _},
+};
+
+#[doc(no_inline)]
+pub use crate::{
+    io::{AsyncBufRead, AsyncBufReadExt as _},
+    io::{AsyncRead, AsyncReadExt as _},
+    io::{AsyncSeek, AsyncSeekExt as _},
+    io::{AsyncWrite, AsyncWriteExt as _},
+};


### PR DESCRIPTION
Fixes #354

The issue appears to be that the `#[doc(inline)]` on the re-exports from futures-lite takes precedence over the `#[doc(no_inline)]` in the `futures_lite::prelude` module.

Before:
<img width="659" height="661" alt="before" src="https://github.com/user-attachments/assets/5ff690a8-68dc-4d57-8a94-ece6f209d69f" />

After:
<img width="659" height="661" alt="after" src="https://github.com/user-attachments/assets/d8ccb82d-4b11-4928-aba8-358156ca0404" />
