### PR TITLE
Fix build on Haiku OS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ async-net = "2.0.0"
 blocking = "1.3.0"
 futures-lite = "2.0.0"
 
-[target.'cfg(not(target_os = "espidf"))'.dependencies]
+[target.'cfg(not(any(target_os = "espidf", target_os = "haiku")))'.dependencies]
 async-process = "2.0.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ pub use {
 #[doc(inline)]
 pub use {async_channel as channel, async_fs as fs, async_lock as lock, async_net as net};
 
-#[cfg(not(target_os = "espidf"))]
+#[cfg(not(any(target_os = "espidf", target_os = "haiku")))]
 #[doc(inline)]
 pub use async_process as process;
 

--- a/src/spawn.rs
+++ b/src/spawn.rs
@@ -54,7 +54,7 @@ pub fn spawn<T: Send + 'static>(future: impl Future<Output = T> + Send + 'static
 
             // Prevent spawning another thread by running the process driver on this thread.
             let ex = Executor::new();
-            #[cfg(not(target_os = "espidf"))]
+            #[cfg(not(any(target_os = "espidf", target_os = "haiku")))]
             ex.spawn(async_process::driver()).detach();
             ex
         })


### PR DESCRIPTION
This disables async-process on Haiku OS, so smol as a whole is able to build. The same solution seems to be already in place for the espidf target, so I guess this should be okay.