### PR TITLE
chore: improve code comments clarity

### DIFF
--- a/examples/async-h1-server.rs
+++ b/examples/async-h1-server.rs
@@ -11,7 +11,7 @@
 //! - http://localhost:8000/
 //! - https://localhost:8001/ (accept the security prompt in the browser)
 //!
-//! Refer to `README.md` to see how to the TLS certificate was generated.
+//! Refer to `README.md` to see how the TLS certificate was generated.
 
 use std::net::TcpListener;
 

--- a/examples/hyper-server.rs
+++ b/examples/hyper-server.rs
@@ -11,7 +11,7 @@
 //! - http://localhost:8000/
 //! - https://localhost:8001/ (accept the security prompt in the browser)
 //!
-//! Refer to `README.md` to see how to the TLS certificate was generated.
+//! Refer to `README.md` to see how the TLS certificate was generated.
 
 use std::net::{TcpListener, TcpStream};
 use std::pin::Pin;

--- a/examples/simple-server.rs
+++ b/examples/simple-server.rs
@@ -11,7 +11,7 @@
 //! - http://localhost:8000/
 //! - https://localhost:8001/ (accept the security prompt in the browser)
 //!
-//! Refer to `README.md` to see how to the TLS certificate was generated.
+//! Refer to `README.md` to see how the TLS certificate was generated.
 
 use std::net::{TcpListener, TcpStream};
 

--- a/examples/web-crawler.rs
+++ b/examples/web-crawler.rs
@@ -21,7 +21,7 @@ async fn fetch(url: String, sender: Sender<String>) {
     sender.send(body).await.ok();
 }
 
-/// Extracts links from a HTML body.
+/// Extracts links from an HTML body.
 fn links(body: String) -> Vec<String> {
     let mut v = Vec::new();
     for elem in Html::parse_fragment(&body).select(&Selector::parse("a").unwrap()) {


### PR DESCRIPTION
This change corrects minor grammatical errors in several example files, fixing the phrase “how to the TLS certificate was generated” and updating “a HTML body” to “an HTML body” for clearer and more accurate documentation.