### PR TITLE
Migrate to Rust 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "smol"
 # - Create "v2.x.y" git tag
 version = "2.0.2"
 authors = ["Stjepan Glavina <stjepang@gmail.com>"]
-edition = "2018"
+edition = "2021"
 rust-version = "1.85"
 description = "A small and fast async runtime"
 license = "Apache-2.0 OR MIT"

--- a/examples/hyper-client.rs
+++ b/examples/hyper-client.rs
@@ -6,7 +6,6 @@
 //! cargo run --example hyper-client
 //! ```
 
-use std::convert::TryInto;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 


### PR DESCRIPTION
Can also use 2024, but for now...